### PR TITLE
Fix duplicate Sendpulse class and implement message send endpoint

### DIFF
--- a/front/send.php
+++ b/front/send.php
@@ -1,0 +1,41 @@
+<?php
+// Endpoint to send a message
+if (!defined('GLPI_ROOT')) {
+    define('GLPI_ROOT', dirname(__DIR__, 2));
+}
+
+include_once GLPI_ROOT . '/inc/includes.php';
+include_once GLPI_ROOT . '/plugins/tiao/inc/hook.php';
+
+header('Content-Type: application/json');
+
+Session::checkRight('plugin', 'tiao', 'w');
+
+$input = json_decode(file_get_contents('php://input'), true);
+if (!$input || !isset($input['message'])) {
+    http_response_code(400);
+    echo json_encode(['error' => 'Invalid request']);
+    exit;
+}
+
+$message = trim($input['message']);
+
+$sender = new \GlpiPlugin\Tiao\Sendpulse(
+    plugin_tiao_getConfig('api_user'),
+    plugin_tiao_getConfig('api_secret')
+);
+$response = $sender->sendMessage('', $message);
+
+// log message into plugin table
+global $DB;
+$table = $DB->getTable('plugin_tiao_messages');
+$DB->insert($table, [
+    'phone'     => null,
+    'message'   => $message,
+    'origin'    => 'web',
+    'direction' => 'out',
+    'date'      => date('Y-m-d H:i:s')
+]);
+
+echo json_encode($response);
+exit;

--- a/inc/sendpulse.php
+++ b/inc/sendpulse.php
@@ -1,30 +1,6 @@
 <?php
 namespace GlpiPlugin\Tiao;
 
-use Glpi\DB;
-
-class Sendpulse {
-    private $apiUserId;
-    private $apiSecret;
-
-    public function __construct($userId, $secret) {
-        $this->apiUserId = $userId;
-        $this->apiSecret = $secret;
-    }
-
-    /**
-     * Send message via SendPulse API
-     */
-    public function sendMessage($phone, $message) {
-        // TODO: Implement OAuth and cURL request to SendPulse
-        return ['status' => 'stub'];
-    }
-}
-<?php
-namespace GlpiPlugin\Tiao;
-
-use Glpi\DB;
-
 class Sendpulse {
     private $apiUserId;
     private $apiSecret;


### PR DESCRIPTION
## Summary
- remove duplicate Sendpulse class definition
- add front/send.php endpoint used by the chat UI

## Testing
- `php -l inc/sendpulse.php` *(fails: `php: command not found`)*


------
https://chatgpt.com/codex/tasks/task_e_68487e176ca08332acf055d750fe7989